### PR TITLE
Fix Bug (Cast Error into ShardAwareHashedLowLevelMetricDataWrapper and  around tags

### DIFF
--- a/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsDataStoreFactory.java
+++ b/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsDataStoreFactory.java
@@ -140,7 +140,7 @@ public class AuraMetricsDataStoreFactory extends BaseTSDBPlugin
         timeSeriesStorage.addEvent((HashedLowLevelMetricData) data);
       } else {
         final ShardAwareHashedLowLevelMetricDataWrapper wrapper =
-                (ShardAwareHashedLowLevelMetricDataWrapper) shardAwareWrapperPool.claim();
+                (ShardAwareHashedLowLevelMetricDataWrapper) shardAwareWrapperPool.claim().object();
         wrapper.data = (HashedLowLevelMetricData) data;
         timeSeriesStorage.addEvent(wrapper);
       }

--- a/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/ShardAwareHashedLowLevelMetricDataWrapper.java
+++ b/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/ShardAwareHashedLowLevelMetricDataWrapper.java
@@ -186,7 +186,7 @@ public class ShardAwareHashedLowLevelMetricDataWrapper implements
 
   @Override
   public int tagValueLength() {
-    return data.tagKeyLength();
+    return data.tagValueLength();
   }
 
   @Override


### PR DESCRIPTION
## issue
There are the following two bugs

1. cast error
The following code casts to "SharedAwareHashedLowLevelMetricDataWrapper", but an error occurs.
https://github.com/OpenTSDB/opentsdb-aura/blob/acf609dbd2944026e029034cc4bf8ccb80bf1461/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsDataStoreFactory.java#L143

```
java.lang.ClassCastException: net.opentsdb.pools.BlockingQueueObjectPool$LocalPooled cannot be cast to net.opentsdb.aura.metrics.storage.ShardAwareHashedLowLevelMetricDataWrapper
2022-07-08T05:58:58.139095106Z 	at net.opentsdb.aura.metrics.storage.AuraMetricsDataStoreFactory.write(AuraMetricsDataStoreFactory.java:153)
2022-07-08T05:58:58.139102103Z 	at net.opentsdb.aura.metrics.pulsar.PulsarConsumerThread.process(PulsarConsumerThread.java:21)
2022-07-08T05:58:58.139107400Z 	at net.opentsdb.aura.metrics.pulsar.PulsarConsumer.run(PulsarConsumer.java:47)
```

2. wrong value returned by getter around Tag
