### PR TITLE
remove code related TimeShift at DonwsampleConfig

### DIFF
--- a/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsQueryResult.java
+++ b/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsQueryResult.java
@@ -77,12 +77,6 @@ public class AuraMetricsQueryResult implements QueryResult, TimeSpecification {
           for (final QueryNodeConfig node : nodes) {
             if (node != null && node instanceof DownsampleConfig) {
               downsampleConfig = (DownsampleConfig) node;
-              if (((TimeSeriesDataSourceConfig) queryNode.config()).timeShifts() != null) {
-                downsampleConfig.startTime().subtract((TemporalAmount) ((TimeSeriesDataSourceConfig)
-                    queryNode.config()).timeShifts().getValue());
-                downsampleConfig.endTime().subtract((TemporalAmount) ((TimeSeriesDataSourceConfig)
-                    queryNode.config()).timeShifts().getValue());
-              }
               aggregatorConfig = DefaultArrayAggregatorConfig.newBuilder()
                   .setArraySize(downsampleConfig.intervals())
                   .setInfectiousNaN(downsampleConfig.getInfectiousNan())


### PR DESCRIPTION
### issue

Timeshift function queries return values that are not as expected (empty, low DPs, etc.)

### Cause
There is a process that shifts the query period by timeshift, but it is being executed in duplicate.

1. AurametricsQueryResult constractor
https://github.com/OpenTSDB/opentsdb-aura/blob/master/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsQueryResult.java#L80-L85

2. AuraMetricsNumericArrayIterator.next
https://github.com/OpenTSDB/opentsdb-aura/blob/ae3c0421da45680a9d095e8ff53ccad1da5afb82/opentsdb/src/main/java/net/opentsdb/aura/metrics/storage/AuraMetricsNumericArrayIterator.java#L312-L331


The second is COMMITTED in the PR below, but I am not sure what the intent of the code is.
Therefore, I have fixed it to delete the first one.